### PR TITLE
feat: add url-scheme link to task in Things

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -25,8 +25,10 @@ export class LogbookRenderer {
       .map((tag) => `#${prefix}${tag}`)
       .join(" ");
 
+    const taskTitle = `[${task.title}](things:///show?id=${task.uuid}) ${tags}`.trimEnd()
+
     return [
-      `- [x] ${task.title} ${tags}`.trimEnd(),
+      `- [x] ${taskTitle}`,
       ...String(task.notes || "")
         .trimEnd()
         .split("\n")


### PR DESCRIPTION
This adds a link to the task in Things itself via the url-scheme link:
```- [x] [Task title](things:///show?id=FCkSLvZ3FSKM7vxkDhjip7)```

This lets you click on the link and open the Things to the task itself.

### Example of Feature

<img width="598" alt="Screen Shot 2021-05-22 at 3 46 11 PM" src="https://user-images.githubusercontent.com/574871/119239120-fe974a80-bb14-11eb-87e3-de4e94a443aa.png">
