### PR TITLE
Change dynamicTyping value

### DIFF
--- a/src/sqlite.ts
+++ b/src/sqlite.ts
@@ -12,7 +12,7 @@ interface ISpawnResults {
 function parseCSV<T>(csv: Buffer[]): T[] {
   const lines = Buffer.concat(csv).toString("utf-8");
   return Papa.parse<T>(lines, {
-    dynamicTyping: true,
+    dynamicTyping: false,
     header: true,
     newline: "\n",
     skipEmptyLines: true,


### PR DESCRIPTION
The CSV parser won't parse the title of the task as a text if it consists the only numbers. 
After I've changed this param locally my sync works fine.