### PR TITLE
Implemented note body sync in settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export default class ThingsLogbookPlugin extends Plugin {
     );
 
     const daysToTasks: Record<string, ITask[]> = groupBy(
-      tasks.filter((task) => task.stopDate),
+      tasks.filter((task) => task.stopDate).map((task) => task),
       (task) => window.moment.unix(task.stopDate).startOf("day").format()
     );
 

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -27,13 +27,17 @@ export class LogbookRenderer {
 
     const taskTitle = `[${task.title}](things:///show?id=${task.uuid}) ${tags}`.trimEnd()
 
-    return [
-      `- [${task.cancelled ? this.settings.canceledMark : 'x'}] ${taskTitle}`,
-      ...String(task.notes || "")
+    const notes = this.settings.doesSyncNoteBody
+      ? String(task.notes || "")
         .trimEnd()
         .split("\n")
         .filter((line) => !!line)
-        .map((noteLine) => `${tab}${noteLine}`),
+        .map((noteLine) => `${tab}${noteLine}`)
+      : ""
+
+    return [
+      `- [${task.cancelled ? this.settings.canceledMark : 'x'}] ${taskTitle}`,
+      ...notes,
       ...task.subtasks.map(
         (subtask: ISubTask) =>
           `${tab}- [${subtask.completed ? "x" : " "}] ${subtask.title}`

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export interface ISettings {
   hasAcceptedDisclaimer: boolean;
   latestSyncTime: number;
 
+  doesSyncNoteBody: boolean;
   isSyncEnabled: boolean;
   sectionHeading: string;
   syncInterval: number;
@@ -22,6 +23,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   hasAcceptedDisclaimer: false,
   latestSyncTime: 0,
 
+  doesSyncNoteBody: true,
   isSyncEnabled: false,
   syncInterval: DEFAULT_SYNC_FREQUENCY_SECONDS,
   sectionHeading: DEFAULT_SECTION_HEADING,
@@ -52,6 +54,7 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
     });
     this.addSyncEnabledSetting();
     this.addSyncIntervalSetting();
+    this.addDoesSyncToeBody();
   }
 
   addSectionHeadingSetting(): void {
@@ -76,6 +79,17 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
         toggle.setValue(this.plugin.options.isSyncEnabled);
         toggle.onChange(async (isSyncEnabled) => {
           this.plugin.writeOptions({ isSyncEnabled });
+        });
+      });
+  }
+
+  addDoesSyncToeBody() {
+    new Setting(this.containerEl)
+      .setName("Sync note's body")
+      .addToggle((toggle) => {
+        toggle.setValue(this.plugin.options.doesSyncNoteBody);
+        toggle.onChange(async (doesSyncNoteBody) => {
+          this.plugin.writeOptions({ doesSyncNoteBody })
         });
       });
   }


### PR DESCRIPTION
Hello!

In this PR I tried to implement: #34 

Here is the strange thing I noticed during testing. 
If I have canceled (not done, but logged as canceled) task, then corresponding list will be rendered: 
<img width="64" alt="image" src="https://user-images.githubusercontent.com/18665585/163220546-01dd0cf5-614e-4622-a277-92e07f82280b.png">

This causes task not to be checked out.