### PR TITLE
Sync projects as headings

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -48,14 +48,14 @@ export class LogbookRenderer {
   }
 
   public render(tasks: ITask[]): string {
-    const { sectionHeading } = this.settings;
-    const areas = groupBy<ITask>(tasks, (task) => task.area || "");
+    const { sectionHeading, doesSyncProject } = this.settings;
+    const headings = groupBy<ITask>(tasks, (task) => task.area || (doesSyncProject ? task.project : "") || "");
     const headingLevel = getHeadingLevel(sectionHeading);
 
     const output = [sectionHeading];
-    Object.entries(areas).map(([area, tasks]) => {
-      if (area !== "") {
-        output.push(toHeading(area, headingLevel + 1));
+    Object.entries(headings).map(([heading, tasks]) => {
+      if (heading !== "") {
+        output.push(toHeading(heading, headingLevel + 1));
       }
       output.push(...tasks.map(this.renderTask));
     });

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -48,14 +48,14 @@ export class LogbookRenderer {
   }
 
   public render(tasks: ITask[]): string {
-    const { sectionHeading, doesSyncProject } = this.settings;
+    const { sectionHeading, doesSyncProject, doesAddNewlineBeforeHeadings } = this.settings;
     const headings = groupBy<ITask>(tasks, (task) => task.area || (doesSyncProject ? task.project : "") || "");
     const headingLevel = getHeadingLevel(sectionHeading);
 
     const output = [sectionHeading];
     Object.entries(headings).map(([heading, tasks]) => {
       if (heading !== "") {
-        output.push(toHeading(heading, headingLevel + 1));
+        output.push(toHeading(heading, headingLevel + 1, doesAddNewlineBeforeHeadings));
       }
       output.push(...tasks.map(this.renderTask));
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,6 +11,7 @@ export interface ISettings {
   hasAcceptedDisclaimer: boolean;
   latestSyncTime: number;
 
+  doesSyncProject: boolean;
   doesSyncNoteBody: boolean;
   isSyncEnabled: boolean;
   sectionHeading: string;
@@ -23,6 +24,7 @@ export const DEFAULT_SETTINGS = Object.freeze({
   hasAcceptedDisclaimer: false,
   latestSyncTime: 0,
 
+  doesSyncProject: false,
   doesSyncNoteBody: true,
   isSyncEnabled: false,
   syncInterval: DEFAULT_SYNC_FREQUENCY_SECONDS,
@@ -55,6 +57,7 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
     this.addSyncEnabledSetting();
     this.addSyncIntervalSetting();
     this.addDoesSyncNoteBodySetting();
+    this.addDoesSyncProjectSetting();
   }
 
   addSectionHeadingSetting(): void {
@@ -83,7 +86,7 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
       });
   }
 
-  addDoesSyncNoteBodySetting() {
+  addDoesSyncNoteBodySetting(): void {
     new Setting(this.containerEl)
       .setName("Include notes")
       .setDesc('Includes MD notes of a task into the synced Obsidian document')
@@ -93,6 +96,18 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
           this.plugin.writeOptions({ doesSyncNoteBody })
         });
       });
+  }
+
+  addDoesSyncProjectSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Include project")
+        .setDesc("If the Things task belongs to a project, use project name as header instead of area")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.doesSyncProject);
+          toggle.onChange(async (doesSyncProject) => {
+            this.plugin.writeOptions({ doesSyncProject })
+          });
+        });
   }
 
   addSyncIntervalSetting(): void {
@@ -123,6 +138,7 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
         });
       });
   }
+
   addCanceledMarkSetting(): void {
     new Setting(this.containerEl)
         .setName("Canceled Mark")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -11,8 +11,9 @@ export interface ISettings {
   hasAcceptedDisclaimer: boolean;
   latestSyncTime: number;
 
-  doesSyncProject: boolean;
   doesSyncNoteBody: boolean;
+  doesSyncProject: boolean;
+  doesAddNewlineBeforeHeadings: boolean;
   isSyncEnabled: boolean;
   sectionHeading: string;
   syncInterval: number;
@@ -24,8 +25,9 @@ export const DEFAULT_SETTINGS = Object.freeze({
   hasAcceptedDisclaimer: false,
   latestSyncTime: 0,
 
-  doesSyncProject: false,
   doesSyncNoteBody: true,
+  doesSyncProject: false,
+  doesAddNewlineBeforeHeadings: false,
   isSyncEnabled: false,
   syncInterval: DEFAULT_SYNC_FREQUENCY_SECONDS,
   sectionHeading: DEFAULT_SECTION_HEADING,
@@ -50,6 +52,7 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
     this.addSectionHeadingSetting();
     this.addTagPrefixSetting();
     this.addCanceledMarkSetting();
+    this.addDoesAddNewlineBeforeHeadingsSetting();
 
     this.containerEl.createEl("h3", {
       text: "Sync",
@@ -149,6 +152,18 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
           textfield.setValue(this.plugin.options.canceledMark);
           textfield.onChange(async (canceledMark) => {
             this.plugin.writeOptions({ canceledMark });
+          });
+        });
+  }
+
+  addDoesAddNewlineBeforeHeadingsSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Empty line before headings")
+        .setDesc("When grouping tasks with headings by area or project, add an empty line before that heading")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.doesAddNewlineBeforeHeadings);
+          toggle.onChange(async (doesAddNewlineBeforeHeadings) => {
+            this.plugin.writeOptions({ doesAddNewlineBeforeHeadings });
           });
         });
   }

--- a/src/textUtils.ts
+++ b/src/textUtils.ts
@@ -6,9 +6,10 @@ export function getHeadingLevel(line = ""): number | null {
   return heading ? heading[1].length : null;
 }
 
-export function toHeading(title: string, level: number): string {
+export function toHeading(title: string, level: number, addEmptyLine: boolean): string {
+  const emptyLine = addEmptyLine ? "\n" : "";
   const hash = "".padStart(level, "#");
-  return `${hash} ${title}`;
+  return `${emptyLine}${hash} ${title}`;
 }
 
 export function getTab(useTab: boolean, tabSize: number): string {

--- a/src/things.ts
+++ b/src/things.ts
@@ -15,6 +15,7 @@ export interface ITask {
   title: string;
   notes: string;
   area?: string;
+  project?: string;
   tags: string[];
   startDate: number;
   stopDate: number;
@@ -27,6 +28,7 @@ export interface ITaskRecord {
   title?: string;
   notes: string;
   area?: string;
+  project?: string;
   startDate: number;
   stopDate: number;
   status: string;
@@ -103,7 +105,8 @@ async function getTasksFromThingsDb(
         TMTask.stopDate as stopDate,
         TMTask.status as status,
         TMArea.title as area,
-        TMTag.title as tag
+        TMTag.title as tag,
+        TMProject.title as project
     FROM
         TMTask
     LEFT JOIN TMTaskTag
@@ -112,6 +115,8 @@ async function getTasksFromThingsDb(
         ON TMTag.uuid = TMTaskTag.tags
     LEFT JOIN TMArea
         ON TMTask.area = TMArea.uuid
+    LEFT JOIN TMTask TMProject
+        ON TMProject.uuid = TMTask.project
     WHERE
         TMTask.trashed = 0
         AND TMTask.stopDate IS NOT NULL


### PR DESCRIPTION
I use projects extensively in my Things setup, and wanted to have an option to use projects as subheadings when syncing tasks, in the same way as areas are used. The new feature is implemented as an option, disabled by default, so the previous default behavior (group by areas only) is maintained unless the user explicitly enables the option. 

The new behaviour is as follows:
- "Include project" disabled (default), same behaviour as before the new feature:
-- Task has NO AREA: task is directly listed under "Logbook"
-- Task has AN AREA: task is listed under the "Area" subheading, 1 level below "Logbook"
- "Include project" enabled:
-- Task has NO AREA and NO PROJECT: task is directly listed under "Logbook"
-- Task has AN AREA and NO PROJECT: task is listed under the "Area" subheading, 1 level below "Logbook"
-- Task has AN AREA and A PROJECT: task is listed under the "Area" subheading (area has priority over project)
-- Task has NO AREA and A PROJECT: task is listed under the "Project" subheading, 1 level below "Logbook"

Relates to #26. The desired implementations described there are a bit more complex, but should also be doable based on my changes.

Additionally, I added an option to pad the area/project subheadings with a preceding newline. Same thing, disabled by default to maintain previous behavior on update.