### PR TITLE
feat(formatting): insert/collapse empty lines

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "id": "things-logbook",
   "name": "Things Logbook",
   "description": "Sync your Things.app Logbook with daily notes",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "author": "Liam Cain",
   "authorUrl": "https://github.com/liamcain/",
   "isDesktopOnly": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-things-logbook-plugin",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Sync Things.app Logbook with Obsidian",
   "author": "liamcain",
   "main": "main.js",

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -11,6 +11,7 @@ export class LogbookRenderer {
     this.app = app;
     this.settings = settings;
     this.renderTask = this.renderTask.bind(this);
+    this.collapseEmptyLines = this.collapseEmptyLines.bind(this);
   }
 
   renderTask(task: ITask): string {
@@ -47,18 +48,62 @@ export class LogbookRenderer {
       .join("\n");
   }
 
+  collapseEmptyLines(lines: string[]): string[] {
+    const result: string[] = [];
+    let previousWasEmpty = false;
+
+    for (const line of lines) {
+      const isEmpty = line.trim() === "";
+
+      if (isEmpty && !previousWasEmpty) {
+        // only push one empty line for consecutive ones
+        result.push("");
+        previousWasEmpty = true;
+      } else {
+        result.push(line);
+        previousWasEmpty = false;
+      }
+    }
+
+    return result;
+  }
+
   public render(tasks: ITask[]): string {
-    const { sectionHeading, doesSyncProject, doesAddNewlineBeforeHeadings } = this.settings;
+    const {
+      sectionHeading,
+      doesSyncProject,
+      doesCollapseEmptyLines,
+      doesAddNewlineAfterSectionHeading,
+      doesAddNewlineBeforeHeadings,
+      doesAddNewlineAfterHeadings,
+    } = this.settings;
+
     const headings = groupBy<ITask>(tasks, (task) => task.area || (doesSyncProject ? task.project : "") || "");
     const headingLevel = getHeadingLevel(sectionHeading);
 
     const output = [sectionHeading];
+    if (doesAddNewlineAfterSectionHeading) {
+      output.push("");
+    }
+
     Object.entries(headings).map(([heading, tasks]) => {
       if (heading !== "") {
-        output.push(toHeading(heading, headingLevel + 1, doesAddNewlineBeforeHeadings));
+        if (doesAddNewlineBeforeHeadings) {
+          output.push("");
+        }
+
+        output.push(toHeading(heading, headingLevel + 1));
+
+        if (doesAddNewlineAfterHeadings) {
+          output.push("");
+        }
       }
       output.push(...tasks.map(this.renderTask));
     });
+
+    if (doesCollapseEmptyLines) {
+      return this.collapseEmptyLines(output).join("\n");
+    }
 
     return output.join("\n");
   }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -55,10 +55,12 @@ export class LogbookRenderer {
     for (const line of lines) {
       const isEmpty = line.trim() === "";
 
-      if (isEmpty && !previousWasEmpty) {
-        // only push one empty line for consecutive ones
-        result.push("");
-        previousWasEmpty = true;
+      if (isEmpty) {
+        if (!previousWasEmpty) {
+          // only push one empty line for consecutive ones
+          result.push("");
+          previousWasEmpty = true;
+        }
       } else {
         result.push(line);
         previousWasEmpty = false;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,7 +13,10 @@ export interface ISettings {
 
   doesSyncNoteBody: boolean;
   doesSyncProject: boolean;
+  doesCollapseEmptyLines: boolean;
+  doesAddNewlineAfterSectionHeading: boolean;
   doesAddNewlineBeforeHeadings: boolean;
+  doesAddNewlineAfterHeadings: boolean;
   isSyncEnabled: boolean;
   sectionHeading: string;
   syncInterval: number;
@@ -27,7 +30,10 @@ export const DEFAULT_SETTINGS = Object.freeze({
 
   doesSyncNoteBody: true,
   doesSyncProject: false,
+  doesCollapseEmptyLines: false,
+  doesAddNewlineAfterSectionHeading: false,
   doesAddNewlineBeforeHeadings: false,
+  doesAddNewlineAfterHeadings: false,
   isSyncEnabled: false,
   syncInterval: DEFAULT_SYNC_FREQUENCY_SECONDS,
   sectionHeading: DEFAULT_SECTION_HEADING,
@@ -54,7 +60,14 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
     this.addSectionHeadingSetting();
     this.addTagPrefixSetting();
     this.addCanceledMarkSetting();
+
+    this.containerEl.createEl("h4", {
+      text: "Empty Lines",
+    });
+    this.addDoesCollapseEmptyLinesSetting();
+    this.addDoesAddNewlineAfterSectionHeadingSetting();
     this.addDoesAddNewlineBeforeHeadingsSetting();
+    this.addDoesAddNewlineAfterHeadingsSetting();
 
     this.containerEl.createEl("h3", {
       text: "Sync",
@@ -158,6 +171,30 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
         });
   }
 
+  addDoesCollapseEmptyLinesSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Collapse empty lines")
+        .setDesc("Merge consecutive empty lines into a single empty line")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.doesCollapseEmptyLines);
+          toggle.onChange(async (doesCollapseEmptyLines) => {
+            this.plugin.writeOptions({ doesCollapseEmptyLines });
+          });
+        });
+  }
+
+  addDoesAddNewlineAfterSectionHeadingSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Empty line after section heading")
+        .setDesc("Insert an empty line after the section heading")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.doesAddNewlineAfterSectionHeading);
+          toggle.onChange(async (doesAddNewlineAfterSectionHeading) => {
+            this.plugin.writeOptions({ doesAddNewlineAfterSectionHeading });
+          });
+        });
+  }
+
   addDoesAddNewlineBeforeHeadingsSetting(): void {
     new Setting(this.containerEl)
         .setName("Empty line before headings")
@@ -166,6 +203,18 @@ export class ThingsLogbookSettingsTab extends PluginSettingTab {
           toggle.setValue(this.plugin.options.doesAddNewlineBeforeHeadings);
           toggle.onChange(async (doesAddNewlineBeforeHeadings) => {
             this.plugin.writeOptions({ doesAddNewlineBeforeHeadings });
+          });
+        });
+  }
+
+  addDoesAddNewlineAfterHeadingsSetting(): void {
+    new Setting(this.containerEl)
+        .setName("Empty line after headings")
+        .setDesc("When grouping tasks with headings by area or project, add an empty line after that heading")
+        .addToggle((toggle) => {
+          toggle.setValue(this.plugin.options.doesAddNewlineAfterHeadings);
+          toggle.onChange(async (doesAddNewlineAfterHeadings) => {
+            this.plugin.writeOptions({ doesAddNewlineAfterHeadings });
           });
         });
   }

--- a/src/textUtils.ts
+++ b/src/textUtils.ts
@@ -6,10 +6,9 @@ export function getHeadingLevel(line = ""): number | null {
   return heading ? heading[1].length : null;
 }
 
-export function toHeading(title: string, level: number, addEmptyLine: boolean): string {
-  const emptyLine = addEmptyLine ? "\n" : "";
-  const hash = "".padStart(level, "#");
-  return `${emptyLine}${hash} ${title}`;
+export function toHeading(title: string, level: number): string {
+  const hashes = "".padStart(level, "#");
+  return `${hashes} ${title}`;
 }
 
 export function getTab(useTab: boolean, tabSize: number): string {


### PR DESCRIPTION
This PR adds the following settings toggles:

1. Collapse empty lines: Merge consecutive empty lines into a single empty line
2. Empty line after section heading: Insert an empty line after the section heading
3. Empty line after headings: When grouping tasks with headings by area or project, add an empty line after that heading

The settings are off by default so this should not change anything for existing users.

## Testing

Test Project with completed/cancelled Tasks:

<img width="805" alt="image" src="https://github.com/user-attachments/assets/6411fcba-60fe-47d7-bc10-a7c01d4010a9" />

Result after importing with all three toggles ON:

<img width="489" alt="image" src="https://github.com/user-attachments/assets/a8227841-740d-452f-910c-8e0bf4cad1f3" />